### PR TITLE
DHCP and Net list data for checkMetadata()

### DIFF
--- a/openstack-probes.pl
+++ b/openstack-probes.pl
@@ -232,7 +232,6 @@ sub checkMetadata {
         }
     }
     nimLog(1, 'Returned '.scalar(@data).' lines from Neutron/Quantum Intersection of DHCP and Net List');
-
 	foreach my $value (@data) {
 		$value =~ s/^\s*(.*?)\s*$/$1/;
 		my @response = `ip netns exec qdhcp-$value curl -f -s 169.254.169.254`;


### PR DESCRIPTION
Creates an array of DHCP data uuids.
Creates an array of Net list data uuids.
Merges both into an array containing only elements in both.
Let me know if there is something missing.
Thanks,
James
